### PR TITLE
Implement openProjectAsync so project open works on modern platforms

### DIFF
--- a/src/main/java/io/github/rejeb/dataform/language/projectWizard/DataformProjectOpenProcessor.java
+++ b/src/main/java/io/github/rejeb/dataform/language/projectWizard/DataformProjectOpenProcessor.java
@@ -16,15 +16,14 @@
  */
 package io.github.rejeb.dataform.language.projectWizard;
 
+import com.intellij.ide.impl.OpenProjectTask;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ex.ProjectManagerEx;
 import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.platform.PlatformProjectOpenProcessor;
 import com.intellij.projectImport.ProjectOpenProcessor;
 import io.github.rejeb.dataform.language.DataformIcons;
-import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
+import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
 
@@ -47,6 +46,17 @@ public final class DataformProjectOpenProcessor extends ProjectOpenProcessor {
                     || file.findChild("dataform.json") != null;
         }
         return false;
+    }
+
+    @Override
+    public @Nullable Object openProjectAsync(@NotNull VirtualFile virtualFile,
+                                             @Nullable Project projectToClose,
+                                             boolean forceOpenInNewFrame,
+                                             @NotNull kotlin.coroutines.Continuation<? super Project> $completion) {
+        OpenProjectTask task = OpenProjectTask.build()
+                .withProjectToClose(projectToClose)
+                .withForceOpenInNewFrame(forceOpenInNewFrame);
+        return ProjectManagerEx.getInstanceEx().openProject(virtualFile.toNioPath(), task);
     }
 
 }

--- a/src/test/java/io/github/rejeb/dataform/language/setup/DataformInterpreterManagerTestImpl.java
+++ b/src/test/java/io/github/rejeb/dataform/language/setup/DataformInterpreterManagerTestImpl.java
@@ -28,11 +28,6 @@ public class DataformInterpreterManagerTestImpl implements DataformInterpreterMa
     }
 
     @Override
-    public Optional<VirtualFile> dataformCliDir() {
-        return Optional.empty();
-    }
-
-    @Override
     public String currentDataformCoreVersion() {
         return "";
     }


### PR DESCRIPTION
## Issue

On IntelliJ 2026.1, opening a directory that contains `workflow_settings.yaml` or `dataform.json` but no `.idea` folder yet (e.g. a fresh clone of a Dataform repo, via File → Open) fails: the IDE logs `IllegalStateException: Use openProjectAsync instead` and no project window opens. Directories with an existing `.idea` are unaffected, which makes the bug look intermittent.

This PR implements `openProjectAsync` in `DataformProjectOpenProcessor` so such directories open normally, and fixes a test-source compile error (a stub still overrode the removed `dataformCliDir()` method).

Fixes #5

## Testing

- Reproduced the failure on IntelliJ IDEA 2026.1.4 with plugin 0.2.14: opening a fresh Dataform directory fails with the exception above on every attempt.
- Built the plugin from this branch, installed it in the same IDE, and confirmed the same directory now opens as a project.
- `compileTestJava` was broken before the test-stub fix and passes on this branch; existing tests are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)